### PR TITLE
Added task Configure secure listen address

### DIFF
--- a/tasks/configure_tls.yml
+++ b/tasks/configure_tls.yml
@@ -351,3 +351,17 @@
   # - { name: "nsslapd-allow-unauthenticated-binds", value: "{{ 'on' if allow_unauthenticated_binds else 'off' }" }
   when: dirsrv_tls_enabled | bool
   tags: [ dirsrv_tls ]
+
+- name: Configure secure listen address
+  ldap_attr:
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
+    dn: "cn=config"
+    name: "nsslapd-securelistenhost"
+    values: "{{ dirsrv_listen_host }}"
+    state: exact
+  notify: dirsrv restart
+  when: dirsrv_listen_host != None

--- a/tasks/configure_tls.yml
+++ b/tasks/configure_tls.yml
@@ -365,3 +365,4 @@
     state: exact
   notify: dirsrv restart
   when: dirsrv_listen_host != None
+  tags: [ dirsrv_tls ]


### PR DESCRIPTION
Added ask to set attribute nsslapd-securelistenhost to variable `{{ dirsrv_listen_host }}`. This has been added to enable binding of port 636/tcp to `{{ dirsrv_listen_host }}` variable when TLS support is enabled.

It seems like a logical step to me when TLS support is enabled.