### PR TITLE
Fixed a bug in calling handlers when multiple instances run in a loop.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: dirsrv restart
+- name: dirsrv restart "{{ dirsrv_serverid }}"
   service:
     name: "dirsrv@{{ dirsrv_serverid }}"
     state: restarted
 
-- name: dirsrv schema reload
+- name: dirsrv schema reload "{{ dirsrv_serverid }}"
   ldap_entry:
     # This runs after dirsrv restart, if a restart is needed,
     # so TLS status enforcing may have changed.

--- a/tasks/configure_authentication.yml
+++ b/tasks/configure_authentication.yml
@@ -29,7 +29,7 @@
         values: "{{ item.value }}"
         state: exact
       loop: "{{ dirsrv_ldapi_config }}"
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
   rescue:
     - name: Configure LDAPI over LDAPI
@@ -42,7 +42,7 @@
         values: "{{ item.value }}"
         state: exact
       loop: "{{ dirsrv_ldapi_config }}"
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
 # Documentation: https://directory.fedoraproject.org/docs/389ds/design/sasl-mechanism-configuration.html
 # TODO: "none" means "everything is allowed"... how to allow none (or just EXTERNAL that is always enabled but not always allowed or whatever?)

--- a/tasks/configure_plugins.yml
+++ b/tasks/configure_plugins.yml
@@ -25,7 +25,7 @@
     - "cn=UID numbers,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config"
     - "cn=GID numbers,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config"
   when: "'Distributed Numeric Assignment Plugin' in dirsrv_plugins_enabled and not dirsrv_plugins_enabled['Distributed Numeric Assignment Plugin']"
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
 
 - name: Manage the dna shared ranges OUs, required when we have a replica
   block:
@@ -101,7 +101,7 @@
       loop:
         - "cn=UID numbers,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config"
         - "cn=GID numbers,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config"
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
     - name: Configure DNA plugin parameters (UID)
       ldap_attr:
@@ -123,7 +123,7 @@
         - { name: "dnanextvalue", value: "{{ dirsrv_dna_plugin.uid_min }}" }
         - { name: "dnamaxvalue", value: "{{ dirsrv_dna_plugin.uid_max }}" }
         - { name: "dnasharedcfgdn", value: "cn=Account UIDs,ou=Ranges,{{ dirsrv_suffix }}" }
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
     - name: Configure DNA plugin parameters (GID)
       ldap_attr:
@@ -145,6 +145,6 @@
         - { name: "dnanextvalue", value: "{{ dirsrv_dna_plugin.gid_min }}" }
         - { name: "dnamaxvalue", value: "{{ dirsrv_dna_plugin.gid_max }}" }
         - { name: "dnasharedcfgdn", value: "cn=Account GIDs,ou=Ranges,{{ dirsrv_suffix }}" }
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
   when: "'Distributed Numeric Assignment Plugin' in dirsrv_plugins_enabled and dirsrv_plugins_enabled['Distributed Numeric Assignment Plugin']"

--- a/tasks/configure_schema.yml
+++ b/tasks/configure_schema.yml
@@ -9,7 +9,7 @@
     group: dirsrv
   loop: "{{ dirsrv_custom_schema }}"
   tags: [ dirsrv_schema ]
-  notify: dirsrv schema reload
+  notify: dirsrv schema reload "{{ dirsrv_serverid }}"
 
 - name: Search other schema files
   find:
@@ -25,6 +25,6 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dirsrv_found_files['files'] }}"
-  notify: dirsrv schema reload
+  notify: dirsrv schema reload "{{ dirsrv_serverid }}"
   tags: [ dirsrv_schema ]
   when: not dirsrv_allow_other_schema_files

--- a/tasks/configure_tls.yml
+++ b/tasks/configure_tls.yml
@@ -167,7 +167,7 @@
         {{ dirsrv_pkutil_authflag }}
         -W ''
       when: dirsrv_nss_key_count_too_many
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
       # I *think* this may be needed for self-signed certificates, but not entirely sure...
       # - name: Set certificate parameters
@@ -233,7 +233,7 @@
     state: absent
   when: not dirsrv_tls_enabled
   tags: [ dirsrv_tls ]
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
 
 - name: Create RSA configuration for TLS (if enabled)
   ldap_entry:
@@ -249,7 +249,7 @@
     state: present
   when: dirsrv_tls_enabled | bool
   tags: [ dirsrv_tls ]
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
 
 - name: Configure RSA parameters
   ldap_attr:
@@ -269,7 +269,7 @@
     - { name: "nsSSLActivation", value: "on" }
   when: dirsrv_tls_enabled | bool
   tags: [ dirsrv_tls ]
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
 
 # Note: https://www.port389.org/docs/389ds/howto/howto-ssl.html says
 # that other settings will not activate if nsslapd-security is off.
@@ -313,7 +313,7 @@
     - { name: "nsssl2", value: "off" }
     - { name: "nsssl3", value: "off" }
     - { name: "sslVersionMin", value: "TLS{{ dirsrv_tls_min_version }}" }
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
   when: dirsrv_tls_enabled | bool
   tags: [ dirsrv_tls ]
 
@@ -363,6 +363,6 @@
     name: "nsslapd-securelistenhost"
     values: "{{ dirsrv_secure_listen_host }}"
     state: exact
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
   when: dirsrv_secure_listen_host != None
   tags: [ dirsrv_tls ]

--- a/tasks/configure_tls_enforcing.yml
+++ b/tasks/configure_tls_enforcing.yml
@@ -16,7 +16,7 @@
         - { name: "nsslapd-minssf", value: "{{ dirsrv_tls_minssf if dirsrv_tls_enabled and dirsrv_tls_enforced else '0' }}" }
       failed_when: false
       tags: [ dirsrv_tls ]
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"
 
   rescue:
     - name: Configure enforcing of TLS, over TLS
@@ -34,4 +34,4 @@
         - { name: "nsslapd-require-secure-binds", value: "{{ 'on' if dirsrv_tls_enabled and dirsrv_tls_enforced else 'off' }}" }
         - { name: "nsslapd-minssf", value: "{{ dirsrv_tls_minssf if dirsrv_tls_enabled and dirsrv_tls_enforced else '0' }}" }
       tags: [ dirsrv_tls ]
-      notify: dirsrv restart
+      notify: dirsrv restart "{{ dirsrv_serverid }}"

--- a/tasks/install_389ds.yml
+++ b/tasks/install_389ds.yml
@@ -56,7 +56,7 @@
 # TODO: How do we change the Directory Manager password if we need it to change the password?
 - block:
     # We have two distinct templates for the two versions of 389DS' install.inf format
-    - name: Determine right template to use for intall.inf
+    - name: Determine right template to use for install.inf
       set_fact:
         dirsrv_install_template: '{% if dirsrv_legacy %}install-v1.inf.j2{% else %}install-v2.inf.j2{% endif %}'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     name: "nsslapd-listenhost"
     values: "{{ dirsrv_listen_host }}"
     state: exact
-  notify: dirsrv restart
+  notify: dirsrv restart "{{ dirsrv_serverid }}"
   when: dirsrv_listen_host != None
 
 - include: configure_authentication.yml

--- a/templates/install-v2.inf.j2
+++ b/templates/install-v2.inf.j2
@@ -36,6 +36,7 @@ suffix = {{ dirsrv_suffix }}
 {% if dirsrv_create_suffix_entry is defined %}
 create_suffix_entry = {{ "True" if dirsrv_create_suffix_entry else "False" }}
 {% endif %}
+{% if dirsrv_othersuffixes is defined %}
 {% for suffix in dirsrv_othersuffixes %}
 
 [backend-{{ suffix.name }}]
@@ -49,3 +50,4 @@ suffix = {{ suffix.dn }}
 create_suffix_entry = {{ "True" if dirsrv_create_suffix_entry else "False" }}
 {% endif %}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Hello,
    I noticed that if I run the role in order to add many instances of 389ds server, the handlers doesn't keep the right `dirsrv_serverid` value, it keeps only the last one in the loop.

For instance, if my task is:
```
   - name: Install 389ds on each instance
      include_role:
        name: lvps.389ds_server
      loop: "{{ test.instances }}"
      loop_control:
        label: "{{ instance.dirsrv_serverid }}"
        loop_var: instance
      vars:
        dirsrv_serverid: "{{ instance.dirsrv_serverid }}"
        dirsrv_suffix: "{{ instance.dirsrv_suffix }}"
        dirsrv_port: "{{ (instance.dirsrv_port  | default(389, true)) }}"
```
where the inventory is:
```
all:
  children:
    test:
      children:
        ldapservers:
          vars:
            test:
              instances:
                - dirsrv_serverid: 'tst-A'
                  dirsrv_suffix: c=enA
                - dirsrv_serverid: 'tst-B'
                  dirsrv_suffix: c=enB
                  dirsrv_port: 489
```

Then, at the end of "tst-A" installation the handler of `dirsrv restart` runs on 'tst-B' value of `dirsrv_serverid`.
To work correctly I must add the `dirsrv_serverid` value on the name of the handler.

I don't know why, I suppose is something related how Ansible manages the variables in loop. Maybe this is not the better way to fix this, but it works well for me.