### PR TITLE
Centos 9 adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Replication is managed with [another role](https://github.com/lvps/389ds-replica
 ## Requirements
 
 - Ansible 2.10 or newer, for Ansible 2.8 and 2.9 use the 3.1.x releases of this role
-- CentOS 7 or CentOS 8 or other RHEL based OS
+- CentOS 7, CentOS 8, CentOS 9 or other RHEL based OS
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Instance settings
 
-dirsrv_product: '{% if ansible_facts["distribution_major_version"] | int < 8 %}389-ds-base{% else %}@389-directory-server:stable/minimal{% endif %}'
+dirsrv_product: '{% if ansible_facts["distribution_major_version"] | int == 8 %}@389-directory-server:stable/minimal{% else %}389-ds-base{% endif %}'
 dirsrv_suffix: dc=example,dc=com
 dirsrv_bename: userRoot
 dirsrv_othersuffixes: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
   galaxy_tags:
     - ldap
 dependencies: []

--- a/tasks/install_389ds.yml
+++ b/tasks/install_389ds.yml
@@ -3,7 +3,7 @@
   when: "ansible_facts['distribution_major_version'] | int == 7"
 
 - include: tasks/install_389ds_EL8.yml
-  when: "ansible_facts['distribution_major_version'] | int == 8"
+  when: "ansible_facts['distribution_major_version'] | int >= 8"
 
 - name: Determine installed server type (1.3.X or 1.4.X)
   set_fact:


### PR DESCRIPTION
[The previous installation method is returned](https://directory.fedoraproject.org/docs/389ds/download.html#centos-stream-9-el9-ds-2x:~:text=install%20389%2Dds-,CentOS%20Stream%209%2C%20EL9%20(ds%C2%A02.x),-389%2Dds%2Dbase). 389-ds-base is part of AppStream repository in CentOS Stream 9, EL9.
The operability is fully tested. 