### PR TITLE
TLS Fixes with self-signed certificate

### DIFF
--- a/tasks/configure_tls.yml
+++ b/tasks/configure_tls.yml
@@ -231,7 +231,7 @@
     bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=RSA,cn=encryption,cn=config"
     state: absent
-  when: not dirsrv_tls_enabled
+  when: not dirsrv_tls_enabled and not dirsrv_selfsigned_cert
   tags: [ dirsrv_tls ]
   register: dirsrv_restart_condition_tls_2
 

--- a/tasks/configure_tls_enforcing.yml
+++ b/tasks/configure_tls_enforcing.yml
@@ -9,9 +9,9 @@
         bind_pw: "{{ dirsrv_rootdn_password }}"
         dn: "cn=config"
         attributes:
-          nsslapd-require-secure-binds: "{{ 'on' if dirsrv_tls_enabled and dirsrv_tls_enforced else 'off' }}"
-          nsslapd-minssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enabled and dirsrv_tls_enforced else '0' }}"
-          nsslapd-localssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enabled and dirsrv_tls_enforced else '0' }}"
+          nsslapd-require-secure-binds: "{{ 'on' if dirsrv_tls_enforced else 'off' }}"
+          nsslapd-minssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enforced else '0' }}"
+          nsslapd-localssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enforced else '0' }}"
         state: exact
       failed_when: false
       tags: [ dirsrv_tls ]
@@ -27,9 +27,9 @@
         bind_pw: "{{ dirsrv_rootdn_password }}"
         dn: "cn=config"
         attributes:
-          nsslapd-require-secure-binds: "{{ 'on' if dirsrv_tls_enabled and dirsrv_tls_enforced else 'off' }}"
-          nsslapd-minssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enabled and dirsrv_tls_enforced else '0' }}"
-          nsslapd-localssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enabled and dirsrv_tls_enforced else '0' }}"
+          nsslapd-require-secure-binds: "{{ 'on' if dirsrv_tls_enforced else 'off' }}"
+          nsslapd-minssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enforced else '0' }}"
+          nsslapd-localssf: "{{ dirsrv_tls_minssf if dirsrv_tls_enforced else '0' }}"
         state: exact
       tags: [ dirsrv_tls ]
       register: dirsrv_restart_condition_tls_enforcing_2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Check that tls_enforced makes sense
   assert:
     that:
-      - dirsrv_tls_enabled
+      - dirsrv_tls_enabled or dirsrv_selfsigned_cert
     msg: "dirsrv_tls_enforced: true doesn't make sense when dirsrv_tls_enabled: false, enable TLS or disable enforcing"
   when: dirsrv_tls_enforced | bool
   tags: [ dirsrv_tls ]


### PR DESCRIPTION
If dirsrv_selfsigned_cert is set, we shouldn't disable TLS, and should allow TLS to be enforced by the server.

The consistency check in main.yml will already catch the case where no TLS is available and can thus not be enforced. So here we can limit ourselves to check dirsrv_tls_enforced.