### PR TITLE
Add missing filter plugin quote_plus

### DIFF
--- a/filter_plugins/quote_plus.py
+++ b/filter_plugins/quote_plus.py
@@ -1,0 +1,7 @@
+from urllib.parse import quote_plus
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'quote_plus': quote_plus,
+        }


### PR DESCRIPTION
Without this fix, `quote_plus` won't be resolved in standard environments. `quote_plus` is trivial but required to get the quoting right.

Sorry about this mistake, I've had this plugin in my environment for such a long time that I'd forgotten about it.
