### PR TITLE
Add support for ldif remote files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Default: `[]` · Can be changed: **No**
 
 Install these additional LDIF files, by default none (empty array). This corresponds to the `InstallLdifFile` directive in the inf installation file for 389DS <= 1.3. From 1.4 onward, this is done via dsconf.
 
+#### dirsrv_ldif_files_remote
+Default: `false` - can be changed: Yes
+
+The ldif file are on the remote server, not on the ansible controller.
+
+
 #### dirsrv_install_additional_ldif_dir
 Default: `/var/lib/dirsrv/slapd-{{ dirsrv_serverid }}/ldif` · Can be changed: **No**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,9 +18,10 @@ dirsrv_install_examples: false
 dirsrv_install_additional_ldif: []
 # Cannot use /tmp, see https://github.com/lvps/389ds-server/issues/18
 dirsrv_install_additional_ldif_dir: "/var/lib/dirsrv/slapd-{{ dirsrv_serverid }}/ldif"
+# ldif files are already on remote server
+dirsrv_ldif_files_remote: false
 
 # Logging
-
 dirsrv_logging:
   audit:
     enabled: false

--- a/tasks/install_389ds.yml
+++ b/tasks/install_389ds.yml
@@ -54,6 +54,7 @@
       copy:
         src: "{{ item }}"
         dest: "{% if dirsrv_legacy %}/tmp/{% else %}{{ dirsrv_install_additional_ldif_dir }}/{% endif %}{{ item | basename }}"
+        remote_src: "{{ dirsrv_ldif_files_remote }}"
         mode: '400'
         owner: dirsrv
         group: dirsrv
@@ -98,6 +99,7 @@
       copy:
         src: "{{ item }}"
         dest: "{{ dirsrv_install_additional_ldif_dir }}/{{ item | basename }}"
+        remote_src: "{{ dirsrv_ldif_files_remote }}"
         mode: '400'
         owner: dirsrv
         group: dirsrv


### PR DESCRIPTION
Context:
I am templating the extra ldif file before running the role, so the ldif are already copyed to the servers.
So I just need the role to grab them from the remote server.