### PR TITLE
Feature: selinux contexts changeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,16 @@ Default: `true` · Can be changed: Yes
 
 Enable SASL PLAIN authentication: if a client tries to authenticate without TLS and TLS is enforced, this kind of authentication should stop it before it sends the plaintext password, while a SIMPLE bind will send the password and then fail because SSF is too low.
 
+#### dirsrv_selinux_setype
+Default: `user_tmp_t` · Can be changed: yes
+
+This parameter specifies the SELinux type for the Directory Server files. The default setting is `user_tmp_t`, which is suitable for temporary user files.
+
+#### dirsrv_selinux_seuser
+Default: `unconfined_u` · Can be changed: yes 
+
+This parameter defines the SELinux user for the Directory Server. The default setting is `unconfined_u`, allowing the process to run with an unconfined SELinux user context.
+
 ### Variables exclusive to 389DS version 1.4.X
 
 These variables only affect on installations of 389DS version 1.4.X and have no effect on previous versions even if defined.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,11 @@ dirsrv_allow_anonymous_binds: 'rootdse'
 dirsrv_simple_auth_enabled: true
 dirsrv_password_storage_scheme: []
 
+# SELinux
+
+dirsrv_selinux_setype: user_tmp_t
+dirsrv_selinux_seuser: unconfined_u
+
 # It's already off by default
 # allow_unauthenticated_binds: false
 

--- a/tasks/install_389ds.yml
+++ b/tasks/install_389ds.yml
@@ -64,11 +64,20 @@
       loop: "{{ dirsrv_install_additional_ldif }}"
 
     - name: Set SELinux context for additional ldif files (setup-ds.pl)
-      sefcontext:
-        setype: user_tmp_t
-        seuser: unconfined_u
+      community.general.sefcontext:
+        setype: "{{ dirsrv_selinux_setype }}"
+        seuser: "{{ dirsrv_selinux_seuser }}"
         state: present
         target: "{% if dirsrv_legacy %}/tmp/{% else %}{{ dirsrv_install_additional_ldif_dir }}/{% endif %}{{ item | basename }}"
+      when:
+        - not dirsrv_instance_dir_exists
+        - ansible_selinux is defined
+        - ansible_selinux.status == 'enabled'
+        - dirsrv_legacy
+      loop: "{{ dirsrv_install_additional_ldif }}"
+
+    - name: Apply new SELinux file context to filesystem (setup-ds.pl)
+      ansible.builtin.command: "restorecon -irv {% if dirsrv_legacy %}/tmp/{% else %}{{ dirsrv_install_additional_ldif_dir }}/{% endif %}{{ item | basename }}"
       when:
         - not dirsrv_instance_dir_exists
         - ansible_selinux is defined
@@ -109,11 +118,20 @@
       loop: "{{ dirsrv_install_additional_ldif }}"
 
     - name: Set SELinux context for additional ldif files (dsconf)
-      sefcontext:
-        setype: user_tmp_t
-        seuser: unconfined_u
+      community.general.sefcontext:
+        setype: "{{ dirsrv_selinux_setype }}"
+        seuser: "{{ dirsrv_selinux_seuser }}"
         state: present
         target: "{{ dirsrv_install_additional_ldif_dir }}/{{ item | basename }}"
+      when:
+        - not dirsrv_instance_dir_exists
+        - ansible_selinux is defined
+        - ansible_selinux.status == 'enabled'
+        - not dirsrv_legacy
+      loop: "{{ dirsrv_install_additional_ldif }}"
+
+    - name: Apply new SELinux file context to filesystem (dsconf)
+      ansible.builtin.command: "restorecon -irv {{ dirsrv_install_additional_ldif_dir }}/{{ item | basename }}"
       when:
         - not dirsrv_instance_dir_exists
         - ansible_selinux is defined


### PR DESCRIPTION
Adding so the setype and seuser can be overwritten by variables 
Adding so the selinux policy is applyed after added

The restorecon is possible breaking change.

**Note:**
For OL9, it should not be needed to change the selinux policy, but I have kept it AS IS for backward compatibility.
the ldif file will inherit the policy set up by 389ds:
**Affected policy:**
| Path | Type | Context |
|------|------|---------|
|`/var/lib/dirsrv/slapd-default/ldif` | all files | `**system_u:object_r:dirsrv_var_lib_t:s0` |

**All policies:**
| Path | Type | Context |
|------|------|---------|
| `/dev/shm/slapd-.*` | all files | `system_u:object_r:dirsrv_tmpfs_t:s0` |
| `/dev/shm/slapd-default` | all files | `system_u:object_r:dirsrv_tmpfs_t:s0` |
| `/etc/dirsrv(/.*)?` | all files | `system_u:object_r:dirsrv_config_t:s0` |
| `/etc/dirsrv/admin-serv(/.*)?` | all files | `system_u:object_r:dirsrvadmin_config_t:s0` |
| `/etc/dirsrv/dsgw(/.*)?` | all files | `system_u:object_r:dirsrvadmin_config_t:s0` |
| `/etc/dirsrv/slapd-default` | all files | `system_u:object_r:dirsrv_config_t:s0` |
| `/etc/dirsrv/slapd-default/schema` | all files | `system_u:object_r:dirsrv_config_t:s0` |
| `/etc/systemd/system/dirsrv.target.wants(/.*)?` | all files | `system_u:object_r:certmonger_unit_file_t:s0` |
| `/opt/dirsrv/var/run/dirsrv/dsgw/cookies(/.*)?` | all files | `system_u:object_r:httpd_var_run_t:s0` |
| `/usr/lib/dirsrv/cgi-bin(/.*)?` | all files | `system_u:object_r:dirsrvadmin_script_exec_t:s0` |
| `/usr/lib/dirsrv/cgi-bin/ds_create` | regular file | `system_u:object_r:dirsrvadmin_unconfined_script_exec_t:s0` |
| `/usr/lib/dirsrv/cgi-bin/ds_remove` | regular file | `system_u:object_r:dirsrvadmin_unconfined_script_exec_t:s0` |
| `/usr/lib/dirsrv/dsgw-cgi-bin(/.*)?` | all files | `system_u:object_r:dirsrvadmin_script_exec_t:s0` |
| `/usr/lib/systemd/system/dirsrv-admin\.service` | regular file | `system_u:object_r:dirsrvadmin_unit_file_t:s0` |
| `/usr/lib/systemd/system/dirsrv.*` | all files | `system_u:object_r:dirsrv_unit_file_t:s0` |
| `/usr/sbin/ldap-agent` | regular file | `system_u:object_r:dirsrv_snmp_exec_t:s0` |
| `/usr/sbin/ldap-agent-bin` | regular file | `system_u:object_r:dirsrv_snmp_exec_t:s0` |
| `/usr/sbin/ns-slapd` | regular file | `system_u:object_r:dirsrv_exec_t:s0` |
| `/usr/sbin/restart-dirsrv` | regular file | `system_u:object_r:initrc_exec_t:s0` |
| `/usr/sbin/restart-ds-admin` | regular file | `system_u:object_r:dirsrvadmin_exec_t:s0` |
| `/usr/sbin/start-dirsrv` | regular file | `system_u:object_r:initrc_exec_t:s0` |
| `/usr/sbin/start-ds-admin` | regular file | `system_u:object_r:dirsrvadmin_exec_t:s0` |
| `/usr/sbin/stop-ds-admin` | regular file | `system_u:object_r:dirsrvadmin_exec_t:s0` |
| `/usr/share/dirsrv(/.*)?` | all files | `system_u:object_r:dirsrv_share_t:s0` |
| `/var/lib/dirsrv(/.*)?` | all files | `system_u:object_r:dirsrv_var_lib_t:s0` |
| `/var/lib/dirsrv/scripts-INSTANCE` | regular file | `system_u:object_r:bin_t:s0` |
| `/var/lib/dirsrv/slapd-default/bak` | all files | `system_u:object_r:dirsrv_var_lib_t:s0` |
| `/var/lib/dirsrv/slapd-default/db` | all files | `system_u:object_r:dirsrv_var_lib_t:s0` |
|`/var/lib/dirsrv/slapd-default/ldif` | all files | `**system_u:object_r:dirsrv_var_lib_t:s0` |
| `/var/lock/dirsrv(/.*)?` | all files | `system_u:object_r:dirsrv_var_lock_t:s0` |
| `/var/lock/subsys/dirsrv-admin` | regular file | `system_u:object_r:dirsrvadmin_lock_t:s0` |
| `/var/log/dirsrv(/.*)?` | all files | `system_u:object_r:dirsrv_var_log_t:s0` |
| `/var/log/dirsrv/admin-serv(/.*)?` | all files | `system_u:object_r:httpd_log_t:s0` |
| `/var/log/dirsrv/ldap-agent.log.*` | all files | `system_u:object_r:dirsrv_snmp_var_log_t:s0` |
| `/var/log/dirsrv/slapd-default` | all files | `system_u:object_r:dirsrv_var_log_t:s0` |
| `/var/run/dirsrv` | all files | `system_u:object_r:dirsrv_var_run_t:s0` |
| `/var/run/dirsrv(/.*)?` | all files | `system_u:object_r:dirsrv_var_run_t:s0` |
| `/var/run/dirsrv/admin-serv.*` | all files | `system_u:object_r:httpd_var_run_t:s0` |
| `/var/run/ldap-agent\.pid` | all files | `system_u:object_r:dirsrv_snmp_var_run_t:s0` |
| `/var/run/lock/dirsrv/slapd-default` | all files | `system_u:object_r:dirsrv_var_lock_t:s0` |
| `/var/run/slapd.*` | socket | `system_u:object_r:dirsrv_var_run_t:s0` |
