### PR TITLE
Adds optional support for lmdb choice and sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Default: `ldap://localhost` · Can be changed: ¹
 
 Server URI for tasks that connect via LDAP. Since tasks are running on the same server as 389DS, this will be localhost in most cases, no need to customize it.
 
+#### dirsrv_use_mdb
+Default: `unset` - Can be changed: Yes
+
+Starting from version 3.0.0 of 389ds, new instances are no longer created with BerkeleyDB by default but with LMDB (mdb). Depending on the operating system's
+packaged version of 389ds, newly created instances may still be created with BDB.  
+If this variable is unset, the effect would be that of using the default db lib for the installed version of 389ds.
+Setting this variable to true will force the installer to use LMDB.
+
+#### dirsrv_mdb_max_size
+Default: `unset` - Can be changed: Yes
+
+Sets the maximum database size (0 to compute it based on disk size up to 1GB). If left unset, the default value of the installed version of 389ds will be used.
+This only makes sense together with `dirsrv_use_mdb: true`.
+
 #### dirsrv_factory
 Default: `false` · Can be changed: Yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,6 +105,8 @@ dirsrv_ldapi_enabled: false
 dirsrv_sasl_plain_enabled: true
 dirsrv_listen_host:
 dirsrv_secure_listen_host:
+dirsrv_use_mdb:
+dirsrv_mdb_max_size:
 
 # Display supported cipher suites:
 # ldapsearch -xLLL -H ldap://server.example.com:389 -D "cn=Directory Manager" -W -b 'cn=encryption,cn=config' -s base nsSSLSupportedCiphers -o ldif-wrap=no dn: cn=encryption,cn=config

--- a/templates/install-v2.inf.j2
+++ b/templates/install-v2.inf.j2
@@ -16,6 +16,12 @@ instance_name = {{ dirsrv_serverid }}
 port = {{ dirsrv_port }}
 root_dn = {{ dirsrv_rootdn }}
 root_password = {{ dirsrv_rootdn_password }}
+{% if dirsrv_use_mdb %}
+db_lib = mdb
+{% if dirsrv_mdb_max_size is defined %}
+mdb_max_size = {{ dirsrv_mdb_max_size }}
+{% endif %}
+{% endif %}
 {% if dirsrv_selfsigned_cert is defined %}
 self_sign_cert = {{ "True" if dirsrv_selfsigned_cert else "False" }}
 {% endif %}


### PR DESCRIPTION
This pr adds `dirsrv_use_mdb` and `dirsrv_mdb_max_size`. 
Both those parameters modify the installation template only if explicitly set, as I think that the correct behaviour is to rely on the default values of the 389ds_base parameters that those options control. I.e. if the user does not have a choice, they should go with the default value of the distribution's 389ds_base, and not have a default value enforced by this role.

-- from https://www.port389.org/docs/389ds/FAQ/Berkeley-DB-deprecation.html

```
Starting from version 3.0.0 New instances are no longer created with BerkeleyDB by default but with LMDB.

Newly created instances are still created with BerkeleyDB by default while libdb is flagged as deprecated since Fedora 33, this change is about to:
 + create LMDB instances by default.
 + warn that BerkeleyDB is deprecated and may be removed in future versions.
```