### PR TITLE
Replace SASL plain toggle with mechanisms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@ Default: `false` · Can be changed: Yes
 
 Enable LDAPI (connect to the server via a UNIX socket at `ldapi:///var/run/dirsrv/slapd-{{ dirsrv_serverid }}.socket`). Note that this is subject to TLS enforcing and TLS is not supported, so it's useless if you set dirsrv_tls_enforced to true.
 
-#### dirsrv_sasl_mechanisms
-Default: `[PLAIN]` · Can be changed: Yes
+#### dirsrv_allowed_sasl_mechanisms
+Default: `not set` · Can be changed: Yes
 
-List of SASL mechanisms to allow in addition to `EXTERNAL`, which is always enabled. `EXTERNAL` allows certificate-based authentication over TLS and cannot be disabled.
+List of SASL mechanisms to allow in addition to `EXTERNAL`, which is always enabled. `EXTERNAL` allows certificate-based authentication over TLS and cannot be disabled. If this variable is not set, the 389-DS default is used, which allows all supported mechanisms.
 
 Common values include `PLAIN`, `GSSAPI` and `GSS-SPNEGO`. Set to `[]` to restrict to `EXTERNAL` only.
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,14 @@ Default: `false` · Can be changed: Yes
 
 Enable LDAPI (connect to the server via a UNIX socket at `ldapi:///var/run/dirsrv/slapd-{{ dirsrv_serverid }}.socket`). Note that this is subject to TLS enforcing and TLS is not supported, so it's useless if you set dirsrv_tls_enforced to true.
 
-#### dirsrv_sasl_plain_enabled
-Default: `true` · Can be changed: Yes
+#### dirsrv_sasl_mechanisms
+Default: `[PLAIN]` · Can be changed: Yes
 
-Enable SASL PLAIN authentication: if a client tries to authenticate without TLS and TLS is enforced, this kind of authentication should stop it before it sends the plaintext password, while a SIMPLE bind will send the password and then fail because SSF is too low.
+List of SASL mechanisms to allow in addition to `EXTERNAL`, which is always enabled. `EXTERNAL` allows certificate-based authentication over TLS and cannot be disabled.
+
+Common values include `PLAIN`, `GSSAPI` and `GSS-SPNEGO`. Set to `[]` to restrict to `EXTERNAL` only.
+
+Note: `PLAIN` transmits credentials in base64-encoding and should only be used when TLS is enforced, as the password is included in the bind request itself and is not protected at the SASL layer.
 
 #### dirsrv_selinux_setype
 Default: `user_tmp_t` · Can be changed: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,7 +102,7 @@ dirsrv_selinux_seuser: unconfined_u
 
 dirsrv_factory: false
 dirsrv_ldapi_enabled: false
-dirsrv_sasl_plain_enabled: true
+dirsrv_sasl_mechanisms: ['PLAIN']
 dirsrv_listen_host:
 dirsrv_secure_listen_host:
 dirsrv_use_mdb:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,7 +102,10 @@ dirsrv_selinux_seuser: unconfined_u
 
 dirsrv_factory: false
 dirsrv_ldapi_enabled: false
-dirsrv_sasl_mechanisms: ['PLAIN']
+
+# By default all supported mechanisms are enabled, but you can use this variable to limit the list of enabled mechanisms.
+# The EXTERNAL mechanism is always enabled, so you don't need to add it to the list.
+# dirsrv_allowed_sasl_mechanisms: ['PLAIN']
 dirsrv_listen_host:
 dirsrv_secure_listen_host:
 dirsrv_use_mdb:

--- a/tasks/configure_authentication.yml
+++ b/tasks/configure_authentication.yml
@@ -41,31 +41,18 @@
       register: dirsrv_restart_condition_auth_2
 
 # Documentation: https://directory.fedoraproject.org/docs/389ds/design/sasl-mechanism-configuration.html
-# TODO: "none" means "everything is allowed"... how to allow none (or just EXTERNAL that is always enabled but not always allowed or whatever?)
+# EXTERNAL is always added since it we cannot disable it.
 - name: Configure SASL mechanisms
-  block:
-    - name: Configure SASL
-      community.general.ldap_attrs:
-        server_uri: "{{ dirsrv_server_uri }}"
-        validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
-        start_tls: "{{ dirsrv_starttls_early }}"
-        bind_dn: "{{ dirsrv_rootdn }}"
-        bind_pw: "{{ dirsrv_rootdn_password }}"
-        dn: "cn=config"
-        attributes:
-          nsslapd-allowed-sasl-mechanisms: "{{ 'PLAIN' if dirsrv_sasl_plain_enabled else [] }}"
-        state: exact
-      register: dirsrv_sasl_result
-
-  rescue:
-    # Deleting an attribute fails if the the attribute doesn't exist,
-    # yay for idempotence...
-    - name: Assert that task failed successfully
-      ansible.builtin.assert:
-        that:
-          - not dirsrv_sasl_result.changed
-          - "'desc' in dirsrv_sasl_result.details"
-          - "{{ dirsrv_sasl_result.details }}.desc == 'No such attribute'"
+  community.general.ldap_attrs:
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
+    dn: "cn=config"
+    attributes:
+      nsslapd-allowed-sasl-mechanisms: "{{ (['EXTERNAL'] + dirsrv_sasl_mechanisms) | join(' ') }}"
+    state: exact
 
 - name: Configure password storage settings
   block:

--- a/tasks/configure_authentication.yml
+++ b/tasks/configure_authentication.yml
@@ -41,7 +41,7 @@
       register: dirsrv_restart_condition_auth_2
 
 # Documentation: https://directory.fedoraproject.org/docs/389ds/design/sasl-mechanism-configuration.html
-# EXTERNAL is always added since it we cannot disable it.
+# EXTERNAL is always enabled, so we add it to the list of mechanisms to make sure it is always present in the configuration, even if the user did not explicitly add it to the list of mechanisms to enable
 - name: Configure SASL mechanisms
   community.general.ldap_attrs:
     server_uri: "{{ dirsrv_server_uri }}"

--- a/tasks/configure_authentication.yml
+++ b/tasks/configure_authentication.yml
@@ -41,7 +41,9 @@
       register: dirsrv_restart_condition_auth_2
 
 # Documentation: https://directory.fedoraproject.org/docs/389ds/design/sasl-mechanism-configuration.html
-# EXTERNAL is always enabled, so we add it to the list of mechanisms to make sure it is always present in the configuration, even if the user did not explicitly add it to the list of mechanisms to enable
+# If dirsrv_allowed_sasl_mechanisms is not set, the task is skipped and the 389-DS default is used (all mechanisms allowed).
+# EXTERNAL is always prepended to the list since it is always enabled in 389-DS regardless of this setting,
+# ensuring the attribute is never empty when the task runs, which avoids idempotency issues with ldap_attrs.
 - name: Configure SASL mechanisms
   community.general.ldap_attrs:
     server_uri: "{{ dirsrv_server_uri }}"
@@ -51,8 +53,9 @@
     bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=config"
     attributes:
-      nsslapd-allowed-sasl-mechanisms: "{{ (['EXTERNAL'] + dirsrv_sasl_mechanisms) | join(' ') }}"
+      nsslapd-allowed-sasl-mechanisms: "{{ (['EXTERNAL'] + dirsrv_allowed_sasl_mechanisms) | join(' ') }}"
     state: exact
+  when: dirsrv_allowed_sasl_mechanisms is defined and dirsrv_allowed_sasl_mechanisms is not none
 
 - name: Configure password storage settings
   block:


### PR DESCRIPTION
refactor: replace dirsrv_sasl_plain_enabled with dirsrv_sasl_mechanisms

Replace the single-mechanism toggle dirsrv_sasl_plain_enabled with a
more flexible dirsrv_sasl_mechanisms list variable. EXTERNAL is now
always included as it is always available in 389-DS regardless of
configuration, which also prevents ldap_attrs from failing when trying
to delete a non-existent attribute.

Default is [PLAIN] to preserve backward compatibility.